### PR TITLE
feat: add more layout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,22 @@ require("lazy").setup({
 require("key-analyzer").setup({
     -- Name of the command to use for the plugin
     command_name = "KeyAnalyzer", -- or nil to disable the command
-    
+
     -- Customize the highlight groups
     highlights = {
         bracket_used = "KeyAnalyzerBracketUsed",
-        letter_used = "KeyAnalyzerLetterUsed", 
+        letter_used = "KeyAnalyzerLetterUsed",
         bracket_unused = "KeyAnalyzerBracketUnused",
         letter_unused = "KeyAnalyzerLetterUnused",
         promo_highlight = "KeyAnalyzerPromo",
-        
+
         -- Set to false if you want to define highlights manually
         define_default_highlights = true,
     },
+
+    -- Keyboard layout to use
+    -- Available options are: qwerty, colemak, colemak-dh
+    layout = "qwerty",
 })
 ```
 

--- a/lua/key-analyzer/config.lua
+++ b/lua/key-analyzer/config.lua
@@ -21,6 +21,7 @@ KeyAnalyzer.options = {
         -- If you are using any of the built-in highlight groups you should leave this enabled
         define_default_highlights = true,
     },
+    layout = "qwerty",
 }
 
 ---@private

--- a/lua/key-analyzer/main.lua
+++ b/lua/key-analyzer/main.lua
@@ -19,7 +19,7 @@ local COLEMAK_KEYBOARD_LAYOUT = {
     { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
     { "q", "w", "f", "p", "g", "j", "l", "u", "y", ";", "[", "]" },
     { "a", "r", "s", "t", "d", "h", "n", "e", "i", "o", "'" },
-    { "z", "x", "c", "v", "b", "k", "h", ",", ".", "/" },
+    { "z", "x", "c", "v", "b", "k", "m", ",", ".", "/" },
 }
 -- COLEMAK DH keyboard layout representation
 local COLEMAK_DH_KEYBOARD_LAYOUT = {

--- a/lua/key-analyzer/main.lua
+++ b/lua/key-analyzer/main.lua
@@ -5,12 +5,28 @@ local main = {}
 
 local current_maps = {}
 
+local KEYBOARD_LAYOUT = {}
 -- QWERTY keyboard layout representation
-local KEYBOARD_LAYOUT = {
+local QWERTY_KEYBOARD_LAYOUT = {
     { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
     { "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]" },
     { "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'" },
     { "z", "x", "c", "v", "b", "n", "m", ",", ".", "/" },
+}
+
+-- COLEMAK  keyboard layout representation
+local COLEMAK_KEYBOARD_LAYOUT = {
+    { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
+    { "q", "w", "f", "p", "g", "j", "l", "u", "y", ";", "[", "]" },
+    { "a", "r", "s", "t", "d", "h", "n", "e", "i", "o", "'" },
+    { "z", "x", "c", "v", "b", "k", "h", ",", ".", "/" },
+}
+-- COLEMAK DH keyboard layout representation
+local COLEMAK_DH_KEYBOARD_LAYOUT = {
+    { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
+    { "q", "w", "f", "p", "b", "j", "l", "u", "y", ";", "[", "]" },
+    { "a", "r", "s", "t", "g", "m", "n", "e", "i", "o", "'" },
+    { "z", "x", "c", "d", "v", "k", "h", ",", ".", "/" },
 }
 
 -- Row offsets for realistic keyboard layout
@@ -61,11 +77,26 @@ local function get_modified_maps(mode, prefix)
     return maps
 end
 
+-- Set  KEYBOARD_LAYOUT based on selected layout
+local function set_keyboard_layout(layout)
+    vim.notify(vim.inspect(layout))
+    if layout == "qwerty" then
+        KEYBOARD_LAYOUT = QWERTY_KEYBOARD_LAYOUT
+    elseif layout == "colemak" then
+        KEYBOARD_LAYOUT = COLEMAK_KEYBOARD_LAYOUT
+    elseif layout == "colemak-dh" then
+        KEYBOARD_LAYOUT = COLEMAK_DH_KEYBOARD_LAYOUT
+    end
+end
+
 -- Create a visual representation of the keyboard
 local function create_keyboard_visual(maps, mode, modifier)
     local lines = {}
     local highlights = {}
     local config_highlights = _G.KeyAnalyzer.config.highlights
+    local layout = _G.KeyAnalyzer.config.layout
+
+    set_keyboard_layout(layout)
 
     if config_highlights.define_default_highlights then
         -- Create highlight groups for mapped and unmapped keys
@@ -248,6 +279,7 @@ end
 function main.show_keyboard_map(mode, prefix)
     current_maps = get_modified_maps(mode, prefix)
     local visual, highlights = create_keyboard_visual(current_maps, mode, prefix)
+
     show_in_float(visual, highlights, current_maps)
 end
 


### PR DESCRIPTION
## 📃 Summary

This PR will add more keyboard layout options by adding `layout` field inside `opts`.
The default is qwerty. And I added colemak and colemak-dh.  

## 📸 Preview
### colemak dh
![image](https://github.com/user-attachments/assets/98c74c37-2935-48da-ba3f-b78ad56f99ed)

### colemak
![image](https://github.com/user-attachments/assets/89f92ec8-8e5e-44a6-b9e1-7af88075b933)

