### PR TITLE
Add AZERTY layout

### DIFF
--- a/lua/key-analyzer/main.lua
+++ b/lua/key-analyzer/main.lua
@@ -6,34 +6,36 @@ local main = {}
 local current_maps = {}
 
 local KEYBOARD_LAYOUT = {}
--- QWERTY keyboard layout representation
-local QWERTY_KEYBOARD_LAYOUT = {
-    { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
-    { "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]" },
-    { "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'" },
-    { "z", "x", "c", "v", "b", "n", "m", ",", ".", "/" },
-}
 
--- COLEMAK  keyboard layout representation
-local COLEMAK_KEYBOARD_LAYOUT = {
-    { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
-    { "q", "w", "f", "p", "g", "j", "l", "u", "y", ";", "[", "]" },
-    { "a", "r", "s", "t", "d", "h", "n", "e", "i", "o", "'" },
-    { "z", "x", "c", "v", "b", "k", "m", ",", ".", "/" },
-}
--- COLEMAK DH keyboard layout representation
-local COLEMAK_DH_KEYBOARD_LAYOUT = {
-    { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
-    { "q", "w", "f", "p", "b", "j", "l", "u", "y", ";", "[", "]" },
-    { "a", "r", "s", "t", "g", "m", "n", "e", "i", "o", "'" },
-    { "z", "x", "c", "d", "v", "k", "h", ",", ".", "/" },
-}
--- AZERTY keyboard layout representation
-local AZERTY_KEYBOARD_LAYOUT = {
-    { "&", "é", '"', "'", "(", "-", "è", "_", "ç", "à", ")", "=" },
-    { "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$" },
-    { "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "*" },
-    { "w", "x", "c", "v", "b", "n", ",", ";", ":", "!" },
+local AVAILABLE_KEYBOARD_LAYOUTS = {
+    -- QWERTY keyboard layout representation
+    qwerty = {
+        { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
+        { "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]" },
+        { "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'" },
+        { "z", "x", "c", "v", "b", "n", "m", ",", ".", "/" },
+    },
+    -- COLEMAK  keyboard layout representation
+    colemak = {
+        { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
+        { "q", "w", "f", "p", "g", "j", "l", "u", "y", ";", "[", "]" },
+        { "a", "r", "s", "t", "d", "h", "n", "e", "i", "o", "'" },
+        { "z", "x", "c", "v", "b", "k", "m", ",", ".", "/" },
+    },
+    -- COLEMAK DH keyboard layout representation
+    colemak_dh = {
+        { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },
+        { "q", "w", "f", "p", "b", "j", "l", "u", "y", ";", "[", "]" },
+        { "a", "r", "s", "t", "g", "m", "n", "e", "i", "o", "'" },
+        { "z", "x", "c", "d", "v", "k", "h", ",", ".", "/" },
+    },
+    -- AZERTY keyboard layout representation
+    azerty = {
+        { "&", "é", '"', "'", "(", "-", "è", "_", "ç", "à", ")", "=" },
+        { "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$" },
+        { "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "*" },
+        { "w", "x", "c", "v", "b", "n", ",", ";", ":", "!" },
+    }
 }
 
 -- Row offsets for realistic keyboard layout
@@ -86,15 +88,14 @@ end
 
 -- Set  KEYBOARD_LAYOUT based on selected layout
 local function set_keyboard_layout(layout)
-    vim.notify(vim.inspect(layout))
-    if layout == "qwerty" then
-        KEYBOARD_LAYOUT = QWERTY_KEYBOARD_LAYOUT
-    elseif layout == "colemak" then
-        KEYBOARD_LAYOUT = COLEMAK_KEYBOARD_LAYOUT
-    elseif layout == "colemak-dh" then
-        KEYBOARD_LAYOUT = COLEMAK_DH_KEYBOARD_LAYOUT
-    elseif layout == "azerty" then
-        KEYBOARD_LAYOUT = AZERTY_KEYBOARD_LAYOUT
+    local keyboard = AVAILABLE_KEYBOARD_LAYOUTS[layout]
+    if not keyboard then
+        vim.notify(
+            string.format("Invalid '%s' layout", layout),
+            vim.log.levels.ERROR
+        )
+    else
+        KEYBOARD_LAYOUT = keyboard
     end
 end
 

--- a/lua/key-analyzer/main.lua
+++ b/lua/key-analyzer/main.lua
@@ -28,6 +28,13 @@ local COLEMAK_DH_KEYBOARD_LAYOUT = {
     { "a", "r", "s", "t", "g", "m", "n", "e", "i", "o", "'" },
     { "z", "x", "c", "d", "v", "k", "h", ",", ".", "/" },
 }
+-- AZERTY keyboard layout representation
+local AZERTY_KEYBOARD_LAYOUT = {
+    { "&", "é", '"', "'", "(", "-", "è", "_", "ç", "à", ")", "=" },
+    { "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$" },
+    { "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "*" },
+    { "w", "x", "c", "v", "b", "n", ",", ";", ":", "!" },
+}
 
 -- Row offsets for realistic keyboard layout
 local ROW_OFFSETS = {
@@ -86,6 +93,8 @@ local function set_keyboard_layout(layout)
         KEYBOARD_LAYOUT = COLEMAK_KEYBOARD_LAYOUT
     elseif layout == "colemak-dh" then
         KEYBOARD_LAYOUT = COLEMAK_DH_KEYBOARD_LAYOUT
+    elseif layout == "azerty" then
+        KEYBOARD_LAYOUT = AZERTY_KEYBOARD_LAYOUT
     end
 end
 

--- a/lua/key-analyzer/main.lua
+++ b/lua/key-analyzer/main.lua
@@ -214,10 +214,22 @@ local function get_key_at_cursor()
     return nil
 end
 
+-- Compute the required window width to display the given keyboard layout
+local function compute_window_width(keyboard)
+    local max_width = 0
+    for index, line in ipairs(keyboard) do
+        local width = (#line * 3) + ROW_OFFSETS[index]
+        if width > max_width then
+            max_width = width
+        end
+    end
+    return max_width
+end
+
 -- Display the keyboard map in a floating window
 local function show_in_float(lines, highlights, maps)
     local buf = vim.api.nvim_create_buf(false, true)
-    local width = 37 -- Increased to accommodate brackets and extra keys
+    local width = compute_window_width(KEYBOARD_LAYOUT)
     local height = #lines + 2
 
     -- Configure buffer


### PR DESCRIPTION
## 📃 Summary

This PR's goal is to add `azerty` keyboard layout support.  
Because `azerty`layout size is bigger (_on 3rd line_), the floating window width is now dynamically computed.  

Also, an optimization is proposed to use a table of available layouts and access it directly (avoiding a `if`/`elseif` block).

## 📸 Preview
![2025-01-16-143347_hyprshot](https://github.com/user-attachments/assets/8c1a2bf9-202d-4a8a-8553-875d1669fad3)
