### PR TITLE
Adding QWERTZ (German) layout, and an option to disable link to x.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,18 @@ require("key-analyzer").setup({
     },
 
     -- Keyboard layout to use
-    -- Available options are: qwerty, colemak, colemak-dh
+    -- Available options are: qwerty, colemak, colemak-dh, azerty, qwertz
     layout = "qwerty",
+
+    -- Should a link to https://x.com/OtivDev be displayed?
+    promotion = true,
 })
 ```
 
 ## Limitations
 
  - Not all maps will be shown. For example `<C-W>`, because these built in window maps are not returned by `vim.api.nvim_get_keymap(mode)`. Another example that will not show up are also fold maps (`z`).
- - Currently only US-ANSII layout is supported, but feel free to open a pull request
+ - Currently, `qwerty, colemak, colemak-dh, azerty, qwertz` layouts are supported, but feel free to open a pull request
  - There is no differentiation between upper case and lower case letters, both will show on the visualisation
  - Remember: Some keys may not actually be bindable, for example <C-[>
  - KeyAnalyzer retreives mappings with `vim.api.nvim_get_keymap(mode)`, so local buffer mappings are not shown

--- a/doc/key-analyzer.txt
+++ b/doc/key-analyzer.txt
@@ -32,6 +32,8 @@ Default values:
       -- Keyboard layout to use
       -- Available options are: qwerty, colemak, colemak-dh, azerty, qwertz
       layout = "qwertz",
+      -- Should a link to https://x.com/OtivDev be displayed?
+      promotion = true,
   }
 
 <

--- a/doc/key-analyzer.txt
+++ b/doc/key-analyzer.txt
@@ -29,6 +29,9 @@ Default values:
           -- If you are using any of the built-in highlight groups you should leave this enabled
           define_default_highlights = true,
       },
+      -- Keyboard layout to use
+      -- Available options are: qwerty, colemak, colemak-dh, azerty, qwertz
+      layout = "qwertz",
   }
 
 <

--- a/lua/key-analyzer/config.lua
+++ b/lua/key-analyzer/config.lua
@@ -21,6 +21,8 @@ KeyAnalyzer.options = {
         -- If you are using any of the built-in highlight groups you should leave this enabled
         define_default_highlights = true,
     },
+    -- Keyboard layout to use
+    -- Available options are: qwerty, colemak, colemak-dh, azerty, qwertz
     layout = "qwerty",
 }
 

--- a/lua/key-analyzer/config.lua
+++ b/lua/key-analyzer/config.lua
@@ -24,6 +24,8 @@ KeyAnalyzer.options = {
     -- Keyboard layout to use
     -- Available options are: qwerty, colemak, colemak-dh, azerty, qwertz
     layout = "qwerty",
+    -- Should a link to https://x.com/OtivDev be displayed?
+    promotion = true,
 }
 
 ---@private

--- a/lua/key-analyzer/main.lua
+++ b/lua/key-analyzer/main.lua
@@ -15,6 +15,13 @@ local AVAILABLE_KEYBOARD_LAYOUTS = {
         { "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'" },
         { "z", "x", "c", "v", "b", "n", "m", ",", ".", "/" },
     },
+    -- QWERTZ keyboard layout representation
+    qwertz = {
+        { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "`" },
+        { "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "+" },
+        { "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "#" },
+        { "y", "x", "c", "v", "b", "n", "m", ",", ".", "-" },
+    },
     -- COLEMAK  keyboard layout representation
     colemak = {
         { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=" },

--- a/lua/key-analyzer/main.lua
+++ b/lua/key-analyzer/main.lua
@@ -184,11 +184,12 @@ local function create_keyboard_visual(maps, mode, modifier)
     table.insert(lines, string.format("Key: %s", modifier == "leader" and "<leader>" or modifier))
     table.insert(lines, "") -- Empty line
 
-    -- Shameless plug :(
-    table.insert(lines, "For more vim: https://x.com/OtivDev")
-    table.insert(highlights, { group = config_highlights.promo_highlight, pos = { 9, 0, 50 } })
-
-    table.insert(lines, "") -- Empty line
+    if _G.KeyAnalyzer.config.promotion then
+        -- Shameless plug :(
+        table.insert(lines, "For more vim: https://x.com/OtivDev")
+        table.insert(highlights, { group = config_highlights.promo_highlight, pos = { 9, 0, 50 } })
+        table.insert(lines, "") -- Empty line
+    end
 
     return lines, highlights
 end


### PR DESCRIPTION
## 📃 Summary

* Added QWERTZ German layout
* Added `promotion` option, letting user show/hide the promotion link to x.com, as proposed on [reddit](https://www.reddit.com/r/neovim/comments/1gikghr/comment/lvbyux3/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button). Defaults to `true`.
* Updated documentation

## 📸 Preview

![qwertz_without_promotion](https://github.com/user-attachments/assets/d6534289-b551-4969-b095-8fa6689fdba2)

